### PR TITLE
Remove double spaces and adds "hours ago"

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -12,6 +12,11 @@ Hublot makes Facebook-style datetime-contextual datetimes a cinch for your Activ
 
     10 seconds ago
     2 minutes ago
+
+==== Comment created an hour or less than 24 hours ago
+
+    an hour ago
+    4 hours ago
   
 ==== Comment created today
 

--- a/lib/hublot/pretty.rb
+++ b/lib/hublot/pretty.rb
@@ -16,7 +16,8 @@ module Hublot
       "Sunday" => 7
     }
 
-    pretty_str.gsub('  ', ' ') # Strip out duplicate spaces that may have been mistakes by the engine (this happens sometimes) 
+    # Strip out duplicate spaces that may have been mistakes by the engine (this happens sometimes)
+    pretty_str.gsub('  ', ' ')
   end
 
 private
@@ -28,6 +29,7 @@ private
     return a_minute_ago if a_minute_ago?
     return minutes_ago  if minutes_ago?
     return an_hour_ago  if an_hour_ago?
+    return hours_ago    if hours_ago?
     return today        if is_today?
     return yesterday    if is_yesterday?
     return this_week    if this_week?
@@ -81,6 +83,14 @@ private
 
   def an_hour_ago?
     @expired >= 3600 && @expired <= 7199 # 3600 = 1 hour
+  end
+
+  def hours_ago
+    (@expired/3600).to_i.to_s+' hours ago'
+  end
+
+  def hours_ago?
+    @expired >= 3600 && @expired <= 3600*24-1 # 3600 = 1 hour
   end
 
   def today

--- a/lib/hublot/pretty.rb
+++ b/lib/hublot/pretty.rb
@@ -16,6 +16,12 @@ module Hublot
       "Sunday" => 7
     }
 
+    pretty_str.gsub('  ', ' ') # Strip out duplicate spaces that may have been mistakes by the engine (this happens sometimes) 
+  end
+
+private
+
+  def pretty_str
     return just_now     if just_now?
     return a_second_ago if a_second_ago?
     return seconds_ago  if seconds_ago?
@@ -29,7 +35,6 @@ module Hublot
     return datetimefiesta
   end
 
-private
   def just_now
     'just now'
   end

--- a/lib/hublot/pretty.rb
+++ b/lib/hublot/pretty.rb
@@ -17,7 +17,7 @@ module Hublot
     }
 
     # Strip out duplicate spaces that may have been mistakes by the engine (this happens sometimes)
-    pretty_str.gsub('  ', ' ')
+    pretty_str.gsub(/\s+/, ' ')
   end
 
 private


### PR DESCRIPTION
Adds "hours ago" to make the gem work more like [local time](https://github.com/basecamp/local_time) and adds some code to ensure double spaces don't occur.